### PR TITLE
Charlieplexing

### DIFF
--- a/config/boards/shields/coder/coder.keymap
+++ b/config/boards/shields/coder/coder.keymap
@@ -5,9 +5,18 @@
         compatible = "zmk,keymap";
 
         default_layer {
+            // bindings = <
+            //     &kp Q &kp W
+            //     &kp A &kp S
+            //     &kp E &kp D
+            // >;
             bindings = <
-                &kp A   &kp E
-                &kp LSHFT   &kp X
+                &kp Q
+                &kp W
+                &kp E
+                &kp A
+                &kp S
+                &kp D
             >;
         };
     };

--- a/config/boards/shields/coder/coder.overlay
+++ b/config/boards/shields/coder/coder.overlay
@@ -11,34 +11,48 @@
         display-name = "Default Layout";
         kscan = <&kscan0>;
         transform = <&default_transform>;
-    keys  //                      w   h x y rot rx ry
-	    = <&key_physical_attrs 100 100   0   0   0  0  0>
-	    , <&key_physical_attrs 100 100 100   0   0  0  0>
-	    , <&key_physical_attrs 100 100   0 100   0  0  0>
-	    , <&key_physical_attrs 100 100 100 100   0  0  0>
-	    ;
+        keys = <
+            &key_physical_attrs 100 100   0   0   0  0  0  // Q
+            &key_physical_attrs 100 100 100   0   0  0  0  // W
+            &key_physical_attrs 100 100 200   0   0  0  0  // E
+            &key_physical_attrs 100 100   0 100   0  0  0  // A
+            &key_physical_attrs 100 100 100 100   0  0  0  // S
+            &key_physical_attrs 100 100 200 100   0  0  0  // D
+        >;
     };
 
     default_transform: keymap_transform0 {
         compatible = "zmk,matrix-transform";
-        rows = <2>;
-        columns = <2>;
+        // rows = <2>;
+        // columns = <4>;
+        // map = <
+        //     // RC(0,0) RC(0,1) RC(0,2)
+        //     // RC(1,0) RC(1,1) RC(1,2)
+        //     RC(0,0) RC(0,1)
+        //     RC(1,0) RC(1,1)
+        //     RC(2,0) RC(2,1)
+        // >;
+        rows = <6>;
+        columns = <1>;
         map = <
-            RC(0,0) RC(0,1)
-            RC(1,0) RC(1,1)
+            RC(0,0)  // Q
+            RC(1,0)  // W
+            RC(2,0)  // E
+            RC(3,0)  // A
+            RC(4,0)  // S
+            RC(5,0)  // D
         >;
     };
 
     kscan0: kscan {
-        compatible = "zmk,kscan-gpio-matrix";
-        diode-direction = "col2row";
-        col-gpios
-            = <&xiao_d 5 GPIO_ACTIVE_HIGH>
-            , <&xiao_d 6 GPIO_ACTIVE_HIGH>
-            ;
-        row-gpios
-            = <&xiao_d 7 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
-            , <&xiao_d 8 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>
+        compatible = "zmk,kscan-gpio-charlieplex";
+        wakeup-source;
+
+        interrupt-gpios = <&xiao_d 5 (GPIO_ACTIVE_HIGH | GPIO_PULL_DOWN)>;
+        gpios
+            = <&xiao_d 6 GPIO_ACTIVE_HIGH>
+            , <&xiao_d 7 GPIO_ACTIVE_HIGH>
+            , <&xiao_d 8 GPIO_ACTIVE_HIGH>
             ;
     };
 };


### PR DESCRIPTION
Charlieplexingの検証

配線は下記のようにブレッドボード上で4つのGPIOを使用し、6つのスイッチに接続。nRF52840はUSB 5Vで動かしていて、ダイオードは1N4148を使用。
![Screenshot_20250723-192122~3](https://github.com/user-attachments/assets/ab200b15-8458-48b3-b90b-139292bd92ae)

- 6つのうち2つのキーが反応しない
- 反応するキーについても、反応しない時があり通常のcol2row接続の時と比べて不安定


ダイオードのVfが1V、nRF52840のGPIOが3.3Vを印加している場合だと、スイッチを押したときにダイオードを2個通過するのでVIHに全然届いていないという感じなのでしょうか。Vfが低くてそこそこ安価なダイオードがあまり秋月に見つからないことや、最終的にコイン電池に対応させたいこともあり、電池が3Vを切ったタイミングでも安定して動作できるかなども心配で https://github.com/c-bata/zmk-config-breadboard-test/pull/2 で検証しているMCP23017やMCP23S17のほうが安心かもと考え中。

一旦こちらは寝かせて他の方針検討します。